### PR TITLE
Pass storage_options to read_parquet_dask

### DIFF
--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -203,11 +203,13 @@ class DaskGeoDataFrame(dd.DataFrame):
         self,
         path,
         filesystem=None,
+        storage_options=None,
         npartitions=None,
         p=15,
         compression="snappy",
         tempdir_format=None,
         _retry_args=None,
+        engine_kwargs=None,
     ):
         """
         Repartition and reorder dataframe spatially along a Hilbert space filling curve
@@ -241,7 +243,7 @@ class DaskGeoDataFrame(dd.DataFrame):
         from .io.utils import validate_coerce_filesystem
 
         # Get fsspec filesystem object
-        filesystem = validate_coerce_filesystem(path, filesystem)
+        filesystem = validate_coerce_filesystem(path, filesystem, storage_options)
 
         # Decorator for operations that should be retried
         if _retry_args is None:
@@ -338,7 +340,12 @@ class DaskGeoDataFrame(dd.DataFrame):
         @retryit
         def write_partition(df_part, part_path):
             with filesystem.open(part_path, "wb") as f:
-                df_part.to_parquet(f, compression=compression, index=True)
+                df_part.to_parquet(
+                    f,
+                    compression=compression,
+                    index=True,
+                    **(engine_kwargs or {}),
+                )
 
         def process_partition(df, i):
             subpart_paths = {}

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -508,7 +508,7 @@ class DaskGeoDataFrame(dd.DataFrame):
                 pq.write_metadata(new_schema, f)
         write_commonmetadata_file()
 
-        return read_parquet_dask(path, filesystem=filesystem)
+        return read_parquet_dask(path, filesystem=filesystem, storage_options=storage_options)
 
     def _compute_packing_npartitions(self, npartitions):
         if npartitions is None:

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -203,12 +203,12 @@ class DaskGeoDataFrame(dd.DataFrame):
         self,
         path,
         filesystem=None,
-        storage_options=None,
         npartitions=None,
         p=15,
         compression="snappy",
         tempdir_format=None,
         _retry_args=None,
+        storage_options=None,
         engine_kwargs=None,
     ):
         """

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -78,11 +78,11 @@ class DaskGeoSeries(dd.Series):
     def cx_partitions(self):
         return _DaskPartitionCoordinateIndexer(self, self.partition_sindex)
 
-    def build_sindex(self):
-        def build_sindex(series):
-            series.build_sindex()
+    def build_sindex(self, **kwargs):
+        def build_sindex(series, **kwargs):
+            series.build_sindex(**kwargs)
             return series
-        return self.map_partitions(build_sindex, meta=self._meta)
+        return self.map_partitions(build_sindex, **kwargs, meta=self._meta)
 
     def intersects_bounds(self, bounds):
         return self.map_partitions(lambda s: s.intersects_bounds(bounds))
@@ -195,8 +195,14 @@ class DaskGeoDataFrame(dd.DataFrame):
         return ddf
 
     def pack_partitions_to_parquet(
-            self, path, filesystem=None, npartitions=None, p=15, compression="snappy",
-            tempdir_format=None, _retry_args=None
+        self,
+        path,
+        filesystem=None,
+        npartitions=None,
+        p=15,
+        compression="snappy",
+        tempdir_format=None,
+        _retry_args=None,
     ):
         """
         Repartition and reorder dataframe spatially along a Hilbert space filling curve
@@ -523,11 +529,11 @@ class DaskGeoDataFrame(dd.DataFrame):
             new_series._partition_sindex = self._partition_sindex[new_series.name]
         return new_series
 
-    def build_sindex(self):
-        def build_sindex(df):
-            df.build_sindex()
+    def build_sindex(self, **kwargs):
+        def build_sindex(df, **kwargs):
+            df.build_sindex(**kwargs)
             return df
-        return self.map_partitions(build_sindex, meta=self._meta)
+        return self.map_partitions(build_sindex, **kwargs, meta=self._meta)
 
     def persist(self, **kwargs):
         return self._propagate_props_to_dataframe(

--- a/spatialpandas/geodataframe.py
+++ b/spatialpandas/geodataframe.py
@@ -113,8 +113,9 @@ class GeoDataFrame(pd.DataFrame):
             self.geometry.array, parent=self
         )
 
-    def build_sindex(self):
-        self.geometry.build_sindex()
+    def build_sindex(self, **kwargs):
+        self.geometry.build_sindex(**kwargs)
+        return self
 
     def _ensure_type(self, obj):
         # Override because a GeoDataFrame operation may result in a regular DataFrame,

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -547,9 +547,10 @@ Cannot check equality of {typ} of length {a_len} with:
             self.build_sindex()
         return self._sindex
 
-    def build_sindex(self):
+    def build_sindex(self, **kwargs):
         if self._sindex is None:
-            self._sindex = HilbertRtree(self.bounds)
+            self._sindex = HilbertRtree(self.bounds, **kwargs)
+        return self
 
     @property
     def cx(self):

--- a/spatialpandas/geoseries.py
+++ b/spatialpandas/geoseries.py
@@ -76,8 +76,9 @@ class GeoSeries(pd.Series):
         from .geometry.base import _CoordinateIndexer
         return _CoordinateIndexer(self.array, parent=self)
 
-    def build_sindex(self):
-        self.array.build_sindex()
+    def build_sindex(self, **kwargs):
+        self.array.build_sindex(**kwargs)
+        return self
 
     def intersects_bounds(self, bounds):
         return pd.Series(

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -22,7 +22,11 @@ from ..geometry import (GeometryDtype, LineDtype, MultiLineDtype,
                                     MultiPointDtype, MultiPolygonDtype,
                                     PointDtype, PolygonDtype, RingDtype)
 from ..geometry.base import to_geometry_array
-from ..io.utils import validate_coerce_filesystem
+from ..io.utils import (
+    PathType,
+    _maybe_prepend_protocol,
+    validate_coerce_filesystem,
+)
 
 _geometry_dtypes = [
     PointDtype, MultiPointDtype, RingDtype, LineDtype,
@@ -39,8 +43,12 @@ def _import_geometry_columns(df, geom_cols):
     return df.assign(**new_cols)
 
 
-def _load_parquet_pandas_metadata(path, filesystem=None):
-    filesystem = validate_coerce_filesystem(path, filesystem)
+def _load_parquet_pandas_metadata(
+    path,
+    filesystem=None,
+    storage_options=None,
+):
+    filesystem = validate_coerce_filesystem(path, filesystem, storage_options)
     if not filesystem.exists(path):
         raise ValueError("Path not found: " + path)
 
@@ -85,10 +93,10 @@ def _get_geometry_columns(pandas_metadata):
 
 def to_parquet(
     df: GeoDataFrame,
-    fname,
+    fname: PathType,
     compression: Optional[str] = "snappy",
     index: Optional[bool] = None,
-    **kwargs,
+    **kwargs: Any,
 ) -> None:
     # Standard pandas to_parquet with pyarrow engine
     pd_to_parquet(
@@ -104,12 +112,15 @@ def to_parquet(
 def read_parquet(
     path: str,
     columns: Optional[Iterable[str]] = None,
-    filesystem: Optional[fsspec.spec.AbstractFileSystem] = None,
+    filesystem: Optional[fsspec.AbstractFileSystem] = None,
+    storage_options: Optional[Dict[str, Any]] = None,
+    engine_kwargs: Optional[Dict[str, Any]] = None,
+    **kwargs: Any,
 ) -> GeoDataFrame:
-    filesystem = validate_coerce_filesystem(path, filesystem)
+    filesystem = validate_coerce_filesystem(path, filesystem, storage_options)
 
     # Load pandas parquet metadata
-    metadata = _load_parquet_pandas_metadata(path, filesystem=filesystem)
+    metadata = _load_parquet_pandas_metadata(path, filesystem, storage_options)
 
     # If columns specified, prepend index columns to it
     if columns is not None:
@@ -130,7 +141,11 @@ def read_parquet(
 
     # Load using pyarrow to handle parquet files and directories across filesystems
     df = pq.ParquetDataset(
-        path, filesystem=filesystem, validate_schema=False
+        path,
+        filesystem=filesystem,
+        validate_schema=False,
+        **(engine_kwargs or {}),
+        **kwargs,
     ).read(columns=columns).to_pandas()
 
     # Import geometry columns, not needed for pyarrow >= 0.16
@@ -144,15 +159,17 @@ def read_parquet(
 
 def to_parquet_dask(
     ddf: DaskGeoDataFrame,
-    path,
+    path: PathType,
     compression: Optional[str] = "snappy",
-    filesystem: Optional[fsspec.spec.AbstractFileSystem] = None,
+    filesystem: Optional[fsspec.AbstractFileSystem] = None,
     storage_options: Optional[Dict[str, Any]] = None,
-    **kwargs,
+    engine_kwargs: Optional[Dict[str, Any]] = None,
+    **kwargs: Any,
 ) -> None:
-    assert isinstance(ddf, DaskGeoDataFrame)
-    filesystem = validate_coerce_filesystem(path, filesystem)
-    if path and filesystem.isdir(path):
+    if not isinstance(ddf, DaskGeoDataFrame):
+        raise TypeError(f"Expected DaskGeoDataFrame not {type(ddf)}")
+    filesystem = validate_coerce_filesystem(path, filesystem, storage_options)
+    if "append" not in kwargs and path and filesystem.isdir(path):
         filesystem.rm(path, recursive=True)
 
     dd_to_parquet(
@@ -184,7 +201,12 @@ def to_parquet_dask(
     spatial_metadata = {'partition_bounds': partition_bounds}
     b_spatial_metadata = json.dumps(spatial_metadata).encode('utf')
 
-    pqds = pq.ParquetDataset(path, filesystem=filesystem, validate_schema=False)
+    pqds = pq.ParquetDataset(
+        path,
+        filesystem=filesystem,
+        validate_schema=False,
+        **(engine_kwargs or {}),
+    )
     all_metadata = copy.copy(pqds.common_metadata.metadata)
     all_metadata[b'spatialpandas'] = b_spatial_metadata
     schema = pqds.common_metadata.schema.to_arrow_schema()
@@ -194,14 +216,16 @@ def to_parquet_dask(
 
 
 def read_parquet_dask(
-    path: str,
+    path: PathType,
     columns: Optional[Iterable[str]] = None,
-    filesystem: Optional[fsspec.spec.AbstractFileSystem] = None,
+    filesystem: Optional[fsspec.AbstractFileSystem] = None,
     load_divisions: Optional[bool] = False,
     geometry: Optional[str] = None,
     bounds: Optional[Tuple[Number, Number, Number, Number]] = None,
     categories: Optional[Union[List[str], Dict[str, str]]] = None,
     build_sindex: Optional[bool] = False,
+    storage_options: Optional[Dict[str, Any]] = None,
+    engine_kwargs: Optional[Dict[str, Any]] = None,
 ) -> DaskGeoDataFrame:
     """Read spatialpandas parquet dataset(s) as DaskGeoDataFrame.
 
@@ -244,7 +268,11 @@ def read_parquet_dask(
             raise ValueError('Empty path specification')
 
     # Infer filesystem
-    filesystem = validate_coerce_filesystem(path[0], filesystem)
+    filesystem = validate_coerce_filesystem(
+        path[0],
+        filesystem,
+        storage_options,
+    )
 
     # Expand glob
     if len(path) == 1 and ('*' in path[0] or '?' in path[0] or '[' in path[0]):
@@ -253,9 +281,15 @@ def read_parquet_dask(
 
     # Perform read parquet
     result = _perform_read_parquet_dask(
-        path, columns, filesystem,
-        load_divisions=load_divisions, geometry=geometry, bounds=bounds,
-        categories=categories
+        path,
+        columns,
+        filesystem,
+        load_divisions=load_divisions,
+        geometry=geometry,
+        bounds=bounds,
+        categories=categories,
+        storage_options=storage_options,
+        engine_kwargs=engine_kwargs,
     )
 
     if build_sindex:
@@ -264,25 +298,31 @@ def read_parquet_dask(
     return result
 
 
-def _maybe_prepend_protocol(paths, filesystem):
-    protocol = filesystem.protocol if isinstance(
-        filesystem.protocol, str) else filesystem.protocol[0]
-    if protocol not in ("file", "abstract"):
-        # Add back prefix (e.g. s3://)
-        paths = [
-            "{proto}://{p}".format(proto=protocol, p=p) for p in paths
-        ]
-    return paths
-
-
 def _perform_read_parquet_dask(
-        paths, columns, filesystem, load_divisions, geometry=None, bounds=None,
-        categories=None,
+    paths,
+    columns,
+    filesystem,
+    load_divisions,
+    geometry=None,
+    bounds=None,
+    categories=None,
+    storage_options=None,
+    engine_kwargs=None,
 ):
-    filesystem = validate_coerce_filesystem(paths[0], filesystem)
-    datasets = [pa.parquet.ParquetDataset(
-        path, filesystem=filesystem, validate_schema=False
-    ) for path in paths]
+    filesystem = validate_coerce_filesystem(
+        paths[0],
+        filesystem,
+        storage_options,
+    )
+    engine_kwargs = engine_kwargs or {}
+    datasets = [
+        pa.parquet.ParquetDataset(
+            path,
+            filesystem=filesystem,
+            validate_schema=False,
+            **engine_kwargs,
+        ) for path in paths
+    ]
 
     # Create delayed partition for each piece
     pieces = []
@@ -293,7 +333,11 @@ def _perform_read_parquet_dask(
 
     delayed_partitions = [
         delayed(read_parquet)(
-            piece.path, columns=columns, filesystem=filesystem
+            piece.path,
+            columns=columns,
+            filesystem=filesystem,
+            storage_options=storage_options,
+            engine_kwargs=engine_kwargs,
         )
         for piece in pieces
     ]
@@ -343,10 +387,16 @@ def _perform_read_parquet_dask(
         engine='pyarrow',
         categories=categories,
         gather_statistics=False,
+        storage_options=storage_options,
+        **engine_kwargs,
     )._meta
 
     # Import geometry columns in meta, not needed for pyarrow >= 0.16
-    metadata = _load_parquet_pandas_metadata(paths[0], filesystem=filesystem)
+    metadata = _load_parquet_pandas_metadata(
+        paths[0],
+        filesystem=filesystem,
+        storage_options=storage_options,
+    )
     geom_cols = _get_geometry_columns(metadata)
     if geom_cols:
         meta = _import_geometry_columns(meta, geom_cols)

--- a/spatialpandas/tests/tools/test_sjoin.py
+++ b/spatialpandas/tests/tools/test_sjoin.py
@@ -1,6 +1,5 @@
 import dask.dataframe as dd
 import geopandas as gp
-import hypothesis.strategies as hs
 import numpy as np
 import pandas as pd
 import pytest

--- a/spatialpandas/tests/tools/test_sjoin.py
+++ b/spatialpandas/tests/tools/test_sjoin.py
@@ -15,7 +15,7 @@ from spatialpandas.dask import DaskGeoDataFrame
 try:
     from geopandas._compat import HAS_RTREE, USE_PYGEOS
     gpd_spatialindex = USE_PYGEOS or HAS_RTREE
-except:
+except ImportError:
     try:
         import rtree  # noqa
         gpd_spatialindex = rtree
@@ -27,13 +27,14 @@ if not gpd_spatialindex:
                 allow_module_level=True)
 
 
+@pytest.mark.slow
+@pytest.mark.parametrize("how", ["inner", "left", "right"])
 @given(
     st_point_array(min_size=1, geoseries=True),
     st_polygon_array(min_size=1, geoseries=True),
-    hs.sampled_from(["inner", "left", "right"])
 )
 @hyp_settings
-def test_sjoin(gp_points, gp_polygons, how):
+def test_sjoin(how, gp_points, gp_polygons):
     # join witgh geopandas
     left_gpdf = gp.GeoDataFrame({
         'geometry': gp_points,


### PR DESCRIPTION
I've test these changes using the dask-cloudprovider `FargateCluster`. Without this minor change, the `pack_partitions_to_parquet` will fail with an `OSError: Passed non-file path: ...`. 
